### PR TITLE
Add spaces after some icons

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -40,7 +40,7 @@
     {{- $categories := slice -}}
     {{- range .Params.categories -}}
       {{- $category := partialCached "function/path.html" . . | printf "/categories/%v" | $.Site.GetPage -}}
-      {{- $categories = $categories | append (printf `<a href="%v"><i class="far fa-folder fa-fw"></i>%v</a>` $category.RelPermalink $category.Title) -}}
+      {{- $categories = $categories | append (printf `<a href="%v"><i class="far fa-folder fa-fw"></i>&nbsp;%v</a>` $category.RelPermalink $category.Title) -}}
     {{- end -}}
     {{- with delimit $categories "&nbsp;" -}}
       &nbsp;<span class="post-category">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
         <div class="footer-line copyright">
           {{- /* Copyright year */ -}}
           {{- if ne .Site.Params.footer.copyright false -}}
-            <i class="far fa-copyright fa-fw"></i>
+            <i class="far fa-copyright fa-fw"></i>&nbsp;
             {{- with .Site.Params.footer.since -}}
               <span itemprop="copyrightYear">
                 {{- if lt . now.Year }}{{ . }} - {{ end }}{{ now.Year -}}

--- a/layouts/partials/plugin/icon.html
+++ b/layouts/partials/plugin/icon.html
@@ -1,5 +1,5 @@
 {{- with .Class -}}
-  <i class="{{ . }}"></i>
+  <i class="{{ . }}"></i>&nbsp;
 {{- else -}}
   {{- $src := .Src -}}
   {{- with .Simpleicons -}}
@@ -9,5 +9,5 @@
   {{- if (urls.Parse $src).Host | not -}}
     {{- $src = (resources.Get $src | minify).RelPermalink -}}
   {{- end -}}
-  <i data-svg-src="{{ $src }}"></i>
+  <i data-svg-src="{{ $src }}"></i>&nbsp;
 {{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -39,7 +39,7 @@
         {{- $categories := slice -}}
         {{- range .Params.categories -}}
           {{- $category := partialCached "function/path.html" . . | printf "/categories/%v" | $.Site.GetPage -}}
-          {{- $categories = $categories | append (printf `<a href="%v"><i class="far fa-folder fa-fw"></i>%v</a>` $category.RelPermalink $category.Title) -}}
+          {{- $categories = $categories | append (printf `<a href="%v"><i class="far fa-folder fa-fw"></i>&nbsp;%v</a>` $category.RelPermalink $category.Title) -}}
         {{- end -}}
         {{- with delimit $categories "&nbsp;" -}}
           &nbsp;<span class="post-category">


### PR DESCRIPTION
Add spaces after some icons.

在摘要和文章中的作者和分类、页脚的版权信息、主页的社交图标后面添加空格，观感上更好。