### PR TITLE
fix typo rel noreferrer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -626,7 +626,7 @@ enableEmoji = true
     icp = ""
     # license info (HTML format is supported)
     # 许可协议信息 (支持 HTML 格式)
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
 
   # Section (all posts) page config
   # Section (所有文章) 页面配置
@@ -687,7 +687,7 @@ enableEmoji = true
     fontawesome = true
     # license info (HTML format is supported)
     # 许可协议信息（支持 HTML 格式）
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
     # whether to show link to Raw Markdown content of the content
     # 是否显示原始 Markdown 文档内容的链接
     linkToMarkdown = true

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -313,7 +313,7 @@ Please open the code block below to view the complete sample configuration :(fa-
     # ICP info only in China (HTML format is supported)
     icp = ""
     # license info (HTML format is supported)
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
 
   # {{< version 0.2.0 >}} Section (all posts) page config
   [params.section]
@@ -463,7 +463,7 @@ Please open the code block below to view the complete sample configuration :(fa-
     # {{< version 0.2.0 >}} whether to enable the fontawesome extended syntax
     fontawesome = true
     # license info (HTML format is supported)
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
     # whether to show link to Raw Markdown content of the content
     linkToMarkdown = true
     # {{< version 0.2.4 >}} whether to show the full text content in RSS

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -315,7 +315,7 @@ hugo
     # {{< version 0.2.12 changed >}} ICP 备案信息，仅在中国使用（支持 HTML 格式）
     icp = ""
     # 许可协议信息（支持 HTML 格式）
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
 
   # {{< version 0.2.0 >}} Section（所有文章）页面配置
   [params.section]
@@ -465,7 +465,7 @@ hugo
     # {{< version 0.2.0 >}} 是否使用 fontawesome 扩展语法
     fontawesome = true
     # 许可协议信息（支持 HTML 格式）
-    license = '<a rel="license external nofollow noopener noreffer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
+    license = '<a rel="license external nofollow noopener noreferrer" href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY-NC 4.0</a>'
     # 是否在文章页面显示原始 Markdown 文档链接
     linkToMarkdown = true
     # {{< version 0.2.4 >}} 是否在 RSS 中显示全文内容

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,8 +11,8 @@
       {{- /* Hugo and FixIt */ -}}
       {{- if ne .Site.Params.footer.hugo false -}}
         <div class="footer-line powered">
-          {{- $hugo := printf `<a href="https://gohugo.io/" target="_blank" rel="external nofollow noopener noreffer" title="Hugo %v">Hugo</a>` hugo.Version -}}
-          {{- $theme := .Scratch.Get "version" | printf `<a href="https://github.com/Lruihao/FixIt" target="_blank" rel="external nofollow noopener noreffer" title="FixIt %v"><img class="fixit-icon" src="/images/fixit.svg" alt="FixIt logo" />&nbsp;FixIt</a>` -}}
+          {{- $hugo := printf `<a href="https://gohugo.io/" target="_blank" rel="external nofollow noopener noreferrer" title="Hugo %v">Hugo</a>` hugo.Version -}}
+          {{- $theme := .Scratch.Get "version" | printf `<a href="https://github.com/Lruihao/FixIt" target="_blank" rel="external nofollow noopener noreferrer" title="FixIt %v"><img class="fixit-icon" src="/images/fixit.svg" alt="FixIt logo" />&nbsp;FixIt</a>` -}}
           {{- dict "Hugo" $hugo "Theme" $theme | T "poweredBySome" | safeHTML }}
         </div>
       {{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -52,7 +52,7 @@
                 class="menu-link"
                 href="{{ $url }}"
                 {{ with .Title }}title="{{ . }}"{{ end }}
-                {{ if (urls.Parse $url).Host }}rel="noopener noreffer" target="_blank"{{ end }}
+                {{ if (urls.Parse $url).Host }}rel="noopener noreferrer" target="_blank"{{ end }}
               >
                 {{- with .Pre -}}{{- . | safeHTML }} {{ end }}{{ .Name }}{{ with .Post }} {{ . | safeHTML -}}{{- end -}}
               </a>
@@ -71,7 +71,7 @@
                         class="menu-link"
                         href="{{ $url }}"
                         {{ with .Title }}title="{{ . }}"{{ end }}
-                        {{ if (urls.Parse $url).Host }}rel="noopener noreffer" target="_blank"{{ end }}
+                        {{ if (urls.Parse $url).Host }}rel="noopener noreferrer" target="_blank"{{ end }}
                       >
                         {{- with .Pre -}}{{- . | safeHTML }} {{ end }}{{ .Name }}{{ with .Post }} {{ . | safeHTML -}}{{- end -}}
                       </a>
@@ -219,7 +219,7 @@
                     class="menu-link"
                     href="{{ $url }}"
                     {{ with .Title }}title="{{ . }}"{{ end }}
-                    {{ if (urls.Parse $url).Host }}rel="noopener noreffer" target="_blank"{{ end }}
+                    {{ if (urls.Parse $url).Host }}rel="noopener noreferrer" target="_blank"{{ end }}
                   >
                     {{- with .Pre -}}{{- . | safeHTML }} {{ end }}{{ .Name }}{{ with .Post }} {{ . | safeHTML -}}{{- end -}}
                   </a>
@@ -238,7 +238,7 @@
                         class="menu-link"
                         href="{{ $url }}"
                         {{ with .Title }}title="{{ . }}"{{ end }}
-                        {{ if (urls.Parse $url).Host }}rel="noopener noreffer" target="_blank"{{ end }}
+                        {{ if (urls.Parse $url).Host }}rel="noopener noreferrer" target="_blank"{{ end }}
                       >
                         {{- with .Pre -}}{{- . | safeHTML }} {{ end }}{{ .Name }}{{ with .Post }} {{ . | safeHTML -}}{{- end -}}
                       </a>
@@ -250,7 +250,7 @@
                 class="menu-link"
                 href="{{ $url }}"
                 {{ with .Title }}title="{{ . }}"{{ end }}
-                {{ if (urls.Parse $url).Host }}rel="noopener noreffer" target="_blank"{{ end }}
+                {{ if (urls.Parse $url).Host }}rel="noopener noreferrer" target="_blank"{{ end }}
               >
                 {{- with .Pre -}}{{- . | safeHTML }} {{ end }}{{ .Name }}{{ with .Post }} {{ . | safeHTML -}}{{- end -}}
               </a>

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -19,7 +19,7 @@
         {{- with .Page -}}
           {{- $url = .RelPermalink -}}
         {{- end -}}
-        <a href="{{ $url }}"{{ with .Title | default .Name }} title="{{ . }}"{{ end }}{{ if (urls.Parse $url).Host }} rel="noopener noreffer" target="_blank"{{ end }}>
+        <a href="{{ $url }}"{{ with .Title | default .Name }} title="{{ . }}"{{ end }}{{ if (urls.Parse $url).Host }} rel="noopener noreferrer" target="_blank"{{ end }}>
           {{- dict "Src" $avatar "Alt" $.Site.Author.name | partial "plugin/image.html" -}}
         </a>
       {{- else -}}

--- a/layouts/partials/plugin/link.html
+++ b/layouts/partials/plugin/link.html
@@ -10,7 +10,7 @@
     title="{{ . }}"
   {{ end }}
   {{ if (urls.Parse .Destination).Host | or .Newtab }}
-    {{ $rel = "external nofollow noopener noreffer" }}
+    {{ $rel = "external nofollow noopener noreferrer" }}
     {{ $external = true }}
     target="_blank"
   {{ end }}

--- a/layouts/partials/single/comment.html
+++ b/layouts/partials/single/comment.html
@@ -49,7 +49,7 @@
         {{- $commentConfig = dict "lightgallery" . | dict "artalk" | merge $commentConfig -}}
       {{- end -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://github.com/ArtalkJS/Artalk" rel="external nofollow noopener noreffer">Artalk</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://github.com/ArtalkJS/Artalk" rel="external nofollow noopener noreferrer">Artalk</a>.
       </noscript>
     {{- end -}}
 
@@ -60,7 +60,7 @@
       {{- $source := printf "https://%v.disqus.com/embed.js" $disqus.shortname -}}
       {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://disqus.com/?ref_noscript" rel="external nofollow noopener noreffer">Disqus</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://disqus.com/?ref_noscript" rel="external nofollow noopener noreferrer">Disqus</a>.
       </noscript>
     {{- end -}}
 
@@ -74,7 +74,7 @@
       {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
       {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" (slice $gitalk.owner) | dict "gitalk" | merge $commentConfig -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk" rel="external nofollow noopener noreffer">Gitalk</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk" rel="external nofollow noopener noreferrer">Gitalk</a>.
       </noscript>
     {{- end -}}
 
@@ -101,7 +101,7 @@
       {{- end -}}
       {{- $commentConfig = $valine.emoji | default "google.yml" | printf "data/emoji/%v" | resources.Get | transform.Unmarshal | dict "valine" | merge $commentConfig -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://valine.js.org/" rel="external nofollow noopener noreffer">Valine</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://valine.js.org/" rel="external nofollow noopener noreferrer">Valine</a>.
       </noscript>
     {{- end -}}
 
@@ -145,7 +145,7 @@
         {{- $commentConfig = dict "comment" . | dict "waline" | merge $commentConfig -}}
       {{- end -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://waline.js.org/" rel="external nofollow noopener noreffer">Waline</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://waline.js.org/" rel="external nofollow noopener noreferrer">Waline</a>.
       </noscript>
     {{- end -}}
 
@@ -162,7 +162,7 @@
       {{- $source := printf "https://connect.facebook.net/%v/sdk.js#xfbml=1&version=v5.0&appId=%v&autoLogAppEvents=1" ($facebook.languageCode | default (T "facebookLanguageCode")) $facebook.appId -}}
       {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://developers.facebook.com/docs/plugins/comments/" rel="external nofollow noopener noreffer">Facebook</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://developers.facebook.com/docs/plugins/comments/" rel="external nofollow noopener noreferrer">Facebook</a>.
       </noscript>
     {{- end -}}
 
@@ -189,7 +189,7 @@
       {{- end -}}
       {{- dict "Source" "https://comments.app/js/widget.js?2" "Defer" true "Attr" $attr | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://comments.app/" rel="external nofollow noopener noreffer">Telegram Comments</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://comments.app/" rel="external nofollow noopener noreferrer">Telegram Comments</a>.
       </noscript>
     {{- end -}}
 
@@ -199,7 +199,7 @@
       <div id="commento"></div>
       {{- dict "Source" "https://cdn.commento.io/js/commento.js" "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://commento.io/" rel="external nofollow noopener noreffer">Commento</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://commento.io/" rel="external nofollow noopener noreferrer">Commento</a>.
       </noscript>
     {{- end -}}
 
@@ -213,7 +213,7 @@
       {{- $commentConfig = $utterances.lightTheme | default "github-light" | dict "lightTheme" | dict "utterances" | merge $commentConfig -}}
       {{- $commentConfig = $utterances.darkTheme | default "github-dark" | dict "darkTheme" | dict "utterances" | merge $commentConfig -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://utteranc.es/" rel="external nofollow noopener noreffer">Utterances</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://utteranc.es/" rel="external nofollow noopener noreferrer">Utterances</a>.
       </noscript>
     {{- end -}}
 
@@ -237,7 +237,7 @@
         {{- $commentConfig = dict "lightgallery" . | dict "twikoo" | merge $commentConfig -}}
       {{- end -}}
       <noscript>
-        Please enable JavaScript to view the comments powered by <a href="https://twikoo.js.org/" rel="external nofollow noopener noreffer">Twikoo</a>.
+        Please enable JavaScript to view the comments powered by <a href="https://twikoo.js.org/" rel="external nofollow noopener noreferrer">Twikoo</a>.
       </noscript>
     {{- end -}}
 
@@ -267,7 +267,7 @@
             defer
           ></script>
           <noscript>
-            Please enable JavaScript to view the comments powered by <a href="https://giscus.app/" rel="external nofollow noopener noreffer">giscus</a>.
+            Please enable JavaScript to view the comments powered by <a href="https://giscus.app/" rel="external nofollow noopener noreferrer">giscus</a>.
           </noscript>
         </div>
       {{- end -}}

--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -9,7 +9,7 @@
             {{- dict "Date" . | T "updatedOnDate" -}}
             {{- if $.Site.Params.gitRepo -}}
               {{- with $.GitInfo -}}
-                &nbsp;<a class="git-hash" href="{{ printf `%v/commit/%v` $.Site.Params.gitRepo .Hash }}" rel="external nofollow noopener noreffer" target="_blank" title="commit by {{ .AuthorName }}({{ .AuthorEmail }}) {{ .Hash }}: {{ .Subject }}">
+                &nbsp;<a class="git-hash" href="{{ printf `%v/commit/%v` $.Site.Params.gitRepo .Hash }}" rel="external nofollow noopener noreferrer" target="_blank" title="commit by {{ .AuthorName }}({{ .AuthorEmail }}) {{ .Hash }}: {{ .Subject }}">
                   <i class="fa-solid fa-hashtag fa-fw"></i>{{- .AbbreviatedHash -}}
                 </a>
               {{- end -}}

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -8,6 +8,6 @@
 {{- $resource := resources.Get "svg/version.template.svg" -}}
 {{- $resource = $resource | resources.ExecuteAsTemplate $path (dict "version" $version "label" $label "color" $color) | minify -}}
 {{- $alt := printf "FixIt %v | %v" $label $version -}}
-<a href="{{ $url }}" rel="noopener noreffer" target="_blank">
+<a href="{{ $url }}" rel="noopener noreferrer" target="_blank">
   {{- dict "Src" $resource.RelPermalink "Alt" $alt "Class" "version" | partial "plugin/image.html" -}}
 </a>

--- a/src/js/theme.js
+++ b/src/js/theme.js
@@ -342,7 +342,7 @@ class FixIt {
                       icon: '',
                       href: 'https://lunrjs.com/'
                     };
-              return `<div class="search-footer">Search by <a href="${href}" rel="noopener noreffer" target="_blank">${icon} ${searchType}</a></div>`;
+              return `<div class="search-footer">Search by <a href="${href}" rel="noopener noreferrer" target="_blank">${icon} ${searchType}</a></div>`;
             }
           }
         }


### PR DESCRIPTION
There are typos in the rel attribute. It should be [noreferrer](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer) instead of [noreffer](https://github.com/Lruihao/FixIt/search?q=noreffer).