### PR TITLE
fix waline config imageUploader = false & highlighter = false

### DIFF
--- a/layouts/partials/single/comment.html
+++ b/layouts/partials/single/comment.html
@@ -113,7 +113,7 @@
       {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
       {{- $source := $cdn.walineJS | default "lib/waline/waline.js" -}}
       {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-      {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "body[theme='dark']" "copyright" true | dict "waline" | merge $commentConfig -}}
+      {{- $commentConfig = dict "el" "#waline" "serverURL" $waline.serverURL "lang" .Lang "dark" "body[theme='dark']" "copyright" true "imageUploader" false "highlighter" false | dict "waline" | merge $commentConfig -}}
       {{- with $waline.pageview -}}
         {{- $commentConfig = dict "pageview" . | dict "waline" | merge $commentConfig -}}
       {{- end -}}


### PR DESCRIPTION
imageUploader and highlighter is still enabled even though the config is set to false because waline's default setting for imageUploader & highlighter is enabled.

to disable imageUploader and highlighter, need to explicitly specify imageUploader: false and highlighter: false in the window.config.