### PR TITLE
feat: add support for center-aligned alerts in admonition syntax

### DIFF
--- a/apps/test/content/posts/alert-and-admonition-test.md
+++ b/apps/test/content/posts/alert-and-admonition-test.md
@@ -154,3 +154,8 @@ This is the default example type admonition.
 {{< admonition quote "" false >}}
 This is the default quote type admonition. Aliases: `cite`
 {{< /admonition >}}
+
+## Special Types
+
+> [!center]
+> This paragraph is **center-aligned**.

--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,6 +1,9 @@
 {{- $basicTypes := slice "note" "tip" "important" "warning" "caution" -}}
 
-{{- if .AlertTitle | or .AlertSign | or (.AlertType | in $basicTypes | not) -}}
+{{- if eq .AlertType "center" -}}
+  {{- /* The "center" type is a special case for centering content. */ -}}
+  <blockquote class="blockquote-center">{{ .Text }}</blockquote>
+{{- else if .AlertTitle | or .AlertSign | or (.AlertType | in $basicTypes | not) -}}
   {{- /* The extended syntax is compatible with Obsidian and FixIt admonition shortcode. */ -}}
   {{- $openMap := dict "+" true "-" false -}}
   {{- $open := index $openMap .AlertSign | default true -}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add support for center-aligned alerts in admonition syntax

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

### Screenshots

<img width="1666" height="854" alt="image" src="https://github.com/user-attachments/assets/ffe218d6-7f38-49fa-ab18-cb562210e5f0" />
