### PR TITLE
feat: add styles to hide empty aside and expand article for better la…

### DIFF
--- a/assets/css/_core/_media.scss
+++ b/assets/css/_core/_media.scss
@@ -40,6 +40,21 @@
   }
 }
 
+@media only screen and (max-width: 1200px) and (min-width: 961px) {
+  .wrapper main {
+    // Hide empty aside and expand article when only one aside is empty
+    aside:first-child:empty:has(~ aside:not(:empty)),
+    aside:first-child:not(:empty) ~ aside#toc-auto:empty {
+      display: none;
+    }
+
+    aside:first-child:empty:has(~ aside:not(:empty)) ~ article,
+    aside:first-child:not(:empty) ~ article:has(~ aside:empty) {
+      flex: 3;
+    }
+  }
+}
+
 @media only screen and (max-width: 960px) {
   %page-style {
     width: ROUND(80%, 2px) !important;


### PR DESCRIPTION
…yout on medium screens

<!-- Thank you for contributing! -->

### Description

Hide empty aside and expand article when only one aside is empty on medium screens (961px ~ 1200px).

close #438 

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

