### PR TITLE
fix: dict type page parameters fall back to site parameters using merge behavior

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1166,6 +1166,7 @@ enable = false
 c4u = false
 
 # Page config
+# TODO migrate mapping key to `params` layer in the future
 [params.page]
 # FixIt 0.2.18 | NEW whether to enable the author's avatar of the post
 authorAvatar = true

--- a/layouts/_markup/render-codeblock-json.html
+++ b/layouts/_markup/render-codeblock-json.html
@@ -1,4 +1,4 @@
-{{- $jsonViewer := .Attributes | merge (.Page.Param "jsonViewer") -}}
+{{- $jsonViewer := .Attributes | merge .Page.Params.jsonViewer | merge .Page.Site.Params.jsonViewer -}}
 {{- if $jsonViewer.enable -}}
   {{- $attrs := printf `expand-depth="%v"` $jsonViewer.expanddepth -}}
   {{- $copyable := false -}}

--- a/layouts/_partials/plugin/code-block-wrapper.html
+++ b/layouts/_partials/plugin/code-block-wrapper.html
@@ -1,5 +1,5 @@
 {{- /* Hook for code blocks rendering */ -}}
-{{- $config := .Attributes | merge (.Page.Param "codeblock") -}}
+{{- $config := .Attributes | merge .Page.Params.codeblock | merge .Page.Site.Params.codeblock -}}
 {{- $result := transform.HighlightCodeBlock . -}}
 {{- $wrapper := $result.Wrapped -}}
 

--- a/layouts/_shortcodes/version.html
+++ b/layouts/_shortcodes/version.html
@@ -1,4 +1,4 @@
-{{- $rvc := .Page.Param "repoVersion" -}}
+{{- $rvc := .Page.Params.repoVersion | merge .Page.Site.Params.repoVersion -}}
 {{- $version := .Get 0 -}}
 {{- $type := .Get 1 | default "new" | lower -}}
 {{- $label := T (printf "version.%v" $type) | default (upper $type) -}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://gohugo.io/methods/page/param/

> The `Param` method on a `Page` object looks for the given `KEY` in page parameters, and returns the corresponding value. If it cannot find the `KEY `in page parameters, it looks for the `KEY` in site parameters. If it cannot find the `KEY` in either location, the Param method returns `nil`.

`.Page.Param` is only suitable for simple types.

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
