### PR TITLE
refactor: move the expiration reminder outside the content

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -509,13 +509,12 @@
     json-viewer[boxed] + json-viewer[boxed] {
       margin-top: 0.5rem;
     }
-
-    @import '../_partials/_single/alert';
-    @import '../_partials/_single/code';
-    @import '../_partials/_single/diagram-copy-btn';
-    @import '../_shortcodes';
   }
-
+  
+  @import '../_shortcodes';
+  @import '../_partials/_single/alert';
+  @import '../_partials/_single/code';
+  @import '../_partials/_single/diagram-copy-btn';
   @import '../_partials/_single/reward';
   @import '../_partials/_single/footer';
   @import '../_partials/_single/comment';

--- a/layouts/_partials/plugin/post-chat-ai.html
+++ b/layouts/_partials/plugin/post-chat-ai.html
@@ -73,9 +73,9 @@
   {{- if $chatConfig.enable -}}
     {{- $sourceOpts = dict "Attr" (printf "data-postChat_key=%q" $key) | merge $sourceOpts -}}
     {{- $blackDom := slice
-      ".expiration-reminder"
       "meting-js"
       ".lnt"
+      ".ln"
     -}}
     {{- with $chatConfig.blackDom -}}
       {{- $blackDom = $blackDom | append . -}}

--- a/layouts/_partials/single/expiration-reminder.html
+++ b/layouts/_partials/single/expiration-reminder.html
@@ -1,7 +1,8 @@
 {{- $params := partial "function/params.html" -}}
 {{- $expirationReminder := $params.expirationReminder | default dict -}}
+{{- $isEnabled := $expirationReminder.enable | and (not $params.password) -}}
 
-{{- if $expirationReminder.enable -}}
+{{- if $isEnabled -}}
   {{- $daysAgo := div (sub now.Unix .Lastmod.Unix) 86400 }}
   {{- $reminderThreshold := $expirationReminder.reminder | default 90 }}
   {{- $warningThreshold := $expirationReminder.warning | default 180 }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -176,12 +176,13 @@
     {{- /* Custom block before post content */ -}}
     {{- block "custom-post__content:before" . }}{{ end -}}
 
+    {{- /* Expiration Reminder */ -}}
+    {{- partial "single/expiration-reminder.html" . -}}
+
     {{- /* Content */ -}}
     {{- $content := dict "Content" .Content "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
     <div class="content" id="content"{{ with $params.endFlag }} data-end-flag="{{ . }}"{{ end }}>
       {{- if not $params.password -}}
-        {{- /* Expiration Reminder */ -}}
-        {{- partial "single/expiration-reminder.html" . -}}
         {{- $content -}}
       {{- end -}}
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

To make the content purer and avoid unnecessary content being included when AI tools such as PostChat translate.js retrieve content.

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other
