### PR TITLE
fix(code): code highlighting not styled for typeit shortcode

### DIFF
--- a/apps/test/content/posts/codeblock-test.md
+++ b/apps/test/content/posts/codeblock-test.md
@@ -150,13 +150,21 @@ function add(a, b) {
 
 ## Code block inside other blocks
 
-> [!NOTE]-
+> [!NOTE]+
 >
 > ```js {mode="classic"}
 > function add(a, b) {
 >   return a + b
 > }
 > ```
+
+{{< typeit code=java >}}
+public class HelloWorld {
+    public static void main(String []args) {
+        System.out.println("Hello World");
+    }
+}
+{{< /typeit >}}
 
 {{< details "Code Block inside Details" >}}
 

--- a/assets/css/_partials/_single/_code.scss
+++ b/assets/css/_partials/_single/_code.scss
@@ -69,7 +69,7 @@ pre {
   @include border-radius($global-border-radius);
 
   // lineNumbersInTable=true
-  > .chroma {
+  > div.chroma {
     position: relative;
     background-color: var(#{$rootPrefix}code-block-background-color);
     @include border-radius($global-border-radius);

--- a/layouts/_partials/init/index.html
+++ b/layouts/_partials/init/index.html
@@ -1,4 +1,4 @@
-{{- hugo.Store.Set "version" "v0.4.0" -}}
+{{- hugo.Store.Set "version" "v0.4.1-20260105065156-43ecb1bd" -}}
 {{- .Store.Set "this" dict -}}
 
 {{- partial "init/detection-env.html" . -}}

--- a/layouts/_shortcodes/typeit.html
+++ b/layouts/_shortcodes/typeit.html
@@ -11,7 +11,7 @@
   {{- /* highlight code content without line number */ -}}
   {{- $content = highlight $content (.Get "code") "lineNos=false, noClasses=false" -}}
   {{- /* delete outer label */ -}}
-  {{- $content = replaceRE `.*<code[^<>]*>(?s)(.*)</code>.*` "$1" $content -}}
+  {{- $content = replaceRE `.*<code[^<>]*>(?s)(.*)</code>.*` "<span class=\"chroma\">$1</span>" $content -}}
   {{- if .Get "code-link" -}}
     {{- /* parsing code links */ -}}
     {{- $content = replaceRE `(<span[^<>]*>)([^<>]*)\[([^<>]+)\]\(([^<>]+)\)([^<>]*)(</span>)` "$1$2$6<a href=\"$4\">$3</a>$1$5$6" $content -}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close #679

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Screenshots

**Before**

<img width="956" height="296" alt="image" src="https://github.com/user-attachments/assets/2f0cad1a-a04e-4d8c-9f56-c98eb92b5fc5" />

**After**

<img width="968" height="308" alt="image" src="https://github.com/user-attachments/assets/d1dd7472-d301-4cb3-8500-e0f2655b2318" />
