### PR TITLE
feat(admonition): add support for content-only alerts without titles

### DIFF
--- a/apps/test/content/posts/alert-and-admonition-test.md
+++ b/apps/test/content/posts/alert-and-admonition-test.md
@@ -39,7 +39,7 @@ This article comprehensively tests the **Alerts** Markdown syntax extension and 
 > [!NOTE] FixIt
 > A clean, elegant but advanced Hugo theme.
 
-> [!TIP] This is a title-only alert
+> [!TIP] This is a title-only alert.
 
 ### Foldable Alerts
 

--- a/assets/css/_shortcodes/_admonition.scss
+++ b/assets/css/_shortcodes/_admonition.scss
@@ -7,10 +7,11 @@
   @include border-radius($global-border-radius);
 
   .admonition-title {
-    font-weight: var(--admonition-title-font-weight, bold);
+    font-weight: var(#{$rootPrefix}admonition-title-font-weight, bold);
     margin: 0 -0.75rem;
     padding: 0.25rem 1.8rem;
     border-bottom: 1px solid;
+    position: relative;
     @include border-radius(0);
 
     strong {
@@ -22,8 +23,11 @@
       }
     }
 
-    &:has(+ .details-content > .admonition-content:empty) {
-      --admonition-title-font-weight: normal;
+    // title-only admonition without content
+    &:not(:has(+ .details-content)) {
+      #{$rootPrefix}admonition-title-font-weight: normal;
+      padding: 0.75rem 1rem 0.75rem 1.8rem;
+      border: 0;
     }
   }
 
@@ -34,10 +38,6 @@
     > p {
       margin: 0;
     }
-    // title-only alert
-    &:empty {
-      display: none;
-    }
 
     .code-block .code-header {
       top: initial !important;
@@ -47,14 +47,16 @@
   i.icon {
     font-size: 0.85rem;
     position: absolute;
-    top: 0.6rem;
-    left: 0.4rem;
+    top: 50%;
+    left: 0.9rem;
+    translate: -50% -50%;
   }
 
   i.details-icon {
     position: absolute;
-    top: 0.6rem;
-    right: 0.3rem;
+    top: 50%;
+    right: 0.9rem;
+    translate: 50% -50%;
   }
   
   background-color: var(#{$rootPrefix}admonition-bg-color);
@@ -93,12 +95,12 @@
     margin-bottom: 0.75rem;
   }
 
-  // content-only admonition (no title) 
+  // content-only admonition without title
   &:not(:has(.admonition-title)) {
     border-left: 0;
 
     .admonition-content {
-      padding: 1rem 0.25rem;
+      padding: 0.75rem 0.25rem;
     }
   }
 }

--- a/layouts/_partials/plugin/admonition.html
+++ b/layouts/_partials/plugin/admonition.html
@@ -59,10 +59,12 @@
       {{- end -}}
     </div>
   {{- end }}
-  <div class="details-content">
-    <div class="admonition-content">
-      {{- .Text | safeHTML -}}
+  {{- with .Text -}}
+    <div class="details-content">
+      <div class="admonition-content">
+        {{- . | safeHTML -}}
+      </div>
     </div>
-  </div>
+  {{- end }}
 </div>
 {{- /* EOF */ -}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Sometimes we might need a more concise tooltip that only contains content and no title.

In this case, we can use a tilde `~` as a title placeholder to hide the title and only display the content.

```md
> [!TIP]~
> This is a content-only alert without a title.
```

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] New feature

### Screenshots

<img width="1626" height="298" alt="image" src="https://github.com/user-attachments/assets/aacd8c54-9e18-45b9-ba00-aac8357ae227" />

