### PR TITLE
feat(taxonomy): support taxonomy_icons with shared icon resolver and …

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1205,6 +1205,17 @@ folderSlash = false
 # list of file or folder names to ignore
 ignoreList = []
 
+# FixIt 1.0.0 | NEW Taxonomy icons config
+# Works with [taxonomies]. Configure [taxonomies] first, otherwise taxonomy icons will not take effect.
+[params.taxonomy_icons]
+# syntax: <taxonomy> = [<title icon>, <card icon>, <term title icon>]
+# example:
+# topic = [
+#   "fa-solid fa-book-bookmark",
+#   "fa-solid fa-book",
+#   "fa-solid fa-book-open"
+# ]
+
 # FixIt 0.4.5 | NEW Print config
 [params.print]
 # whether to expand all admonitions before printing

--- a/layouts/_partials/function/get-taxonomy-icon.html
+++ b/layouts/_partials/function/get-taxonomy-icon.html
@@ -1,0 +1,24 @@
+{{- /*
+  Resolve taxonomy icon by slot with site-level overrides.
+
+  @param {String} .Taxonomy taxonomy singular key, e.g. "tag", "category"
+  @param {String} .Slot icon slot: "title", "card", "term"
+  @return {String} icon class
+*/ -}}
+{{- $taxonomy := .Taxonomy | default "category" -}}
+{{- $slot := .Slot | default "title" -}}
+{{- $defaults := dict
+  "tag" (slice "fa-solid fa-tags" "fa-solid fa-tag" "fa-solid fa-tag")
+  "category" (slice "fa-solid fa-folder-tree" "fa-regular fa-folder" "fa-regular fa-folder-open")
+  "collection" (slice "fa-solid fa-layer-group" "fa-solid fa-layer-group" "fa-solid fa-layer-group")
+-}}
+{{- $fallback := index $defaults "category" -}}
+{{- $icons := index $defaults $taxonomy | default $fallback -}}
+{{- with index site.Params "taxonomy_icons" -}}
+  {{- with index . $taxonomy -}}
+    {{- $icons = . | default $icons -}}
+  {{- end -}}
+{{- end -}}
+{{- $slotIndex := index (dict "title" 0 "card" 1 "term" 2) $slot | default 0 -}}
+{{- $icon := index $icons $slotIndex | default (index $fallback $slotIndex) -}}
+{{- return $icon -}}

--- a/layouts/taxonomies.html
+++ b/layouts/taxonomies.html
@@ -1,9 +1,5 @@
 {{- /* Taxonomies Page */ -}}
-{{- $iconMap := dict
-  "category" "fa-regular fa-folder"
-  "collection" "fa-solid fa-layer-group"
--}}
-{{- $icon := index $iconMap .Data.Singular | default $iconMap.category -}}
+{{- $icon := .Params.cardIcon | default (dict "Taxonomy" .Data.Singular "Slot" "card" | partial "function/get-taxonomy-icon.html") -}}
 
 <div class="taxonomy-cards {{ .Data.Plural }}">
   {{- range .Data.Terms.ByCount -}}

--- a/layouts/taxonomy.html
+++ b/layouts/taxonomy.html
@@ -5,12 +5,7 @@
 
 {{- define "content" -}}
   {{- $taxonomies := .Data.Plural -}}
-  {{- $iconMap := dict
-    "categories" "fa-solid fa-folder-tree"
-    "collections" "fa-solid fa-layer-group"
-    "tags" "fa-solid fa-tags"
-  -}}
-  {{- $icon := index $iconMap $taxonomies | default $iconMap.categories -}}
+  {{- $icon := .Params.titleIcon | default (dict "Taxonomy" .Data.Singular "Slot" "title" | partial "function/get-taxonomy-icon.html") -}}
 
   <div class="page archive">
     {{- /* Title */ -}}

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -8,17 +8,8 @@
     {{- /* Title */ -}}
     {{- $taxonomy := .Data.Singular -}}
     {{- $pageCount := len .Pages -}}
-    {{- $termIcon := "" -}}
+    {{- $termIcon := .Params.titleIcon | default (dict "Taxonomy" $taxonomy "Slot" "term" | partial "function/get-taxonomy-icon.html") -}}
     {{- $termTitle := .Title -}}
-    {{- if eq $taxonomy "category" -}}
-      {{- $termIcon = "fa-regular fa-folder-open" -}}
-    {{- else if eq $taxonomy "tag" -}}
-      {{- $termIcon = "fa-solid fa-tag" -}}
-    {{- else if eq $taxonomy "collection" -}}
-      {{- $termIcon = "fa-solid fa-layer-group" -}}
-    {{- else -}}
-      {{- $termTitle = printf "%v - %v" (T $taxonomy | default $taxonomy) .Title -}}
-    {{- end -}}
     <h1 class="single-title animate__animated animate__pulse animate__faster">
       {{- with $termIcon -}}
         {{- dict "Class" (add . " me-1") | partial "plugin/icon.html" -}}


### PR DESCRIPTION
…front matter icon overrides

<!-- Thank you for contributing! -->

### Description

This PR adds configurable taxonomy icons and unifies icon resolving logic across taxonomy templates.

> [!NOTE]
> `params.taxonomy_icons` are effective only when taxonomy is configured.

**What Changed**:

- Added new config section: `params.taxonomy_icons`
  - Syntax: `<taxonomy> = [<title icon>, <card icon>, <term title icon>]`
- Added a shared resolver partial to centralize taxonomy icon lookup.
- Updated taxonomy-related templates to use the shared resolver instead of hardcoded icon maps.
- Added front matter overrides for taxonomy pages:
  - `titleIcon`
  - `cardIcon` (only for taxonomy `_index.md`)

Icon resolving priority now is:

1. Front matter override (`titleIcon` / `cardIcon`)
2. `params.taxonomy_icons` custom config
3. Built-in defaults (`tag`, `category`, `collection`)

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other
