### PR TITLE
fix: Dart Sass compatibility + feat: add imagePreview config for home page

### DIFF
--- a/assets/css/_page/_single/_toc.scss
+++ b/assets/css/_page/_single/_toc.scss
@@ -126,7 +126,7 @@
   .toc-content {
     overflow-y: scroll;
     // TODO 这里计算错误，待重构使用 JS 计算
-    max-height: calc(100vh - #{2 * #{fixit-var(header-height)}});
+    max-height: calc(100vh - 2 * var(--fi-header-height));
     @include scrollbar-width(none, 0);
 
     &.always-active ul,

--- a/hugo.toml
+++ b/hugo.toml
@@ -711,7 +711,7 @@ enable = true
 # special amount of posts in each home posts page
 paginate = 6
 # whether to show featured image preview in home page post list
-imagePreview = false
+imagePreview = true
 
 # FixIt 0.2.16 | CHANGED Social config about the author
 [params.social]

--- a/hugo.toml
+++ b/hugo.toml
@@ -710,6 +710,8 @@ disclaimer = ""
 enable = true
 # special amount of posts in each home posts page
 paginate = 6
+# whether to show featured image preview in home page post list
+imagePreview = false
 
 # FixIt 0.2.16 | CHANGED Social config about the author
 [params.social]

--- a/layouts/_partials/plugin/style.html
+++ b/layouts/_partials/plugin/style.html
@@ -15,7 +15,7 @@
       {{- $resource = $resource | resources.ExecuteAsTemplate . $.Context -}}
     {{- end -}}
     {{- with .ToCSS -}}
-      {{- $options := . | merge (dict "outputStyle" "compressed") -}}
+      {{- $options := . | merge (dict "outputStyle" "compressed" "transpiler" "dartsass" "silenceDeprecations" (slice "import" "global-builtin" "color-functions" "function-units")) -}}
       {{- $resource = $resource | toCSS $options -}}
     {{- end -}}
     {{- if .Minify -}}
@@ -44,3 +44,4 @@
     <link rel="stylesheet" {{ $attrs | safeHTMLAttr }}>
   {{- end -}}
 {{- end -}}
+

--- a/layouts/summary.html
+++ b/layouts/summary.html
@@ -1,6 +1,29 @@
 {{- $params := .Params | merge .Site.Params.page -}}
 
 <article class="single summary" itemscope itemtype="http://schema.org/Article">
+  {{- if not (eq .Site.Params.home.posts.imagePreview false) -}}
+  {{- /* Featured image */ -}}
+  {{- $image := $params.featuredimagepreview | default $params.featuredimage -}}
+  {{- $matches := slice -}}
+  {{- if .Resources.GetMatch "featured-image-preview" -}}
+    {{- $matches = $matches | append "featured-image-preview" -}}
+  {{- else if .Resources.GetMatch "featured-image" -}}
+    {{- $matches = $matches | append "featured-image" -}}
+  {{- end -}}
+  {{- if $image | or (gt (len $matches) 0) -}}
+    <div class="featured-image-preview">
+      <a href="{{ $.RelPermalink }}" aria-label="{{ $.Title }}">
+        {{- $optim := slice
+          (dict "Process" "fill 800x336 Center webp" "descriptor" "800w")
+          (dict "Process" "fill 1200x504 Center webp" "descriptor" "1200w")
+          (dict "Process" "fill 1600x672 Center webp" "descriptor" "1600w")
+        -}}
+        {{- dict "Src" $image "Title" $.Title "Resources" $.Resources "Matches" $matches "Loading" "eager" "Width" "800" "Height" "336" "Sizes" "(max-width: 680px) 100vw, (max-width: 960px) 80vw, (max-width: 1440px) 56vw, 800px" "OptimConfig" $optim "Alt" (printf "Featured image for %v" $.Title) | partial "plugin/image.html" -}}
+      </a>
+    </div>
+  {{- end -}}
+  {{- end -}}
+
   {{- /* Title */ -}}
   <h2 class="single-title" itemprop="name headline">
     {{- with $params.weight -}}
@@ -61,4 +84,3 @@
   </div>
 </article>
 {{- /* EOF */ -}}
-

--- a/layouts/summary.html
+++ b/layouts/summary.html
@@ -1,27 +1,6 @@
 {{- $params := .Params | merge .Site.Params.page -}}
 
 <article class="single summary" itemscope itemtype="http://schema.org/Article">
-  {{- /* Featured image */ -}}
-  {{- $image := $params.featuredimagepreview | default $params.featuredimage -}}
-  {{- $matches := slice -}}
-  {{- if .Resources.GetMatch "featured-image-preview" -}}
-    {{- $matches = $matches | append "featured-image-preview" -}}
-  {{- else if .Resources.GetMatch "featured-image" -}}
-    {{- $matches = $matches | append "featured-image" -}}
-  {{- end -}}
-  {{- if $image | or (gt (len $matches) 0) -}}
-    <div class="featured-image-preview">
-      <a href="{{ $.RelPermalink }}" aria-label="{{ $.Title }}">
-        {{- $optim := slice 
-          (dict "Process" "fill 800x336 Center webp" "descriptor" "800w")
-          (dict "Process" "fill 1200x504 Center webp" "descriptor" "1200w")
-          (dict "Process" "fill 1600x672 Center webp" "descriptor" "1600w") 
-        -}}
-        {{- dict "Src" $image "Title" $.Title "Resources" $.Resources "Matches" $matches "Loading" "eager" "Width" "800" "Height" "336" "Sizes" "(max-width: 680px) 100vw, (max-width: 960px) 80vw, (max-width: 1440px) 56vw, 800px" "OptimConfig" $optim "Alt" (printf "Featured image for %v" $.Title) | partial "plugin/image.html" -}}
-      </a>
-    </div>
-  {{- end -}}
-
   {{- /* Title */ -}}
   <h2 class="single-title" itemprop="name headline">
     {{- with $params.weight -}}
@@ -82,3 +61,4 @@
   </div>
 </article>
 {{- /* EOF */ -}}
+


### PR DESCRIPTION
### Description

This PR addresses two issues:

**1. Dart Sass compatibility (bug fix)**

Hugo deprecated LibSass in v0.153.0 and will remove it in a future release. FixIt's SCSS currently fails to compile with Dart Sass 1.85+ due to two issues:

- `_toc.scss` line 129: `#{2 * #{fixit-var(header-height)}}` performs arithmetic on a CSS custom property, which Dart Sass rejects as an undefined operation. Replaced with valid CSS `calc(100vh - 2 * var(--fi-header-height))`.
- `style.html`: The `toCSS` call defaults to `libsass` transpiler, which cannot resolve `_index.scss` directory imports used throughout the theme. Added `"transpiler" "dartsass"` and silenced Sass deprecation warnings for `@import`, `global-builtin`, `color-functions`, and `function-units` (these are theme-internal and will need a future migration to `@use`).

Without these changes, `hugo build` fails with:
```
TOCSS: failed to transform "/css/style.scss": File to import not found or unreadable: _core.
```

**2. Add `imagePreview` config option (feature)**

Added `[params.home.posts].imagePreview` (default: `true`) to control whether featured image previews are shown in the home page post list. This was available in DoIt (FixIt's predecessor) and is a common request for blogs that prefer text-only summaries on the home page.

Usage:
```toml
[params.home.posts]
  imagePreview = false
```

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/hugo-fixit/FixIt/blob/main/CONTRIBUTING.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving.

### What is the purpose of this pull request?

- [X] Bug fix
- [X] New feature
- [ ] Other
